### PR TITLE
#7 | Fixes Deathspitter cost for Tyranid Warrior

### DIFF
--- a/src/factions/Tyranids/models.json
+++ b/src/factions/Tyranids/models.json
@@ -870,6 +870,10 @@
           {
             "WeaponId": "DEV",
             "Cost": 0
+          },
+          {
+            "WeaponId": "CRM",
+            "Cost": 2
           }
         ],
         "LevelCosts": []


### PR DESCRIPTION
Adds a cost override for Tyranid Warrior so it's 2pts.